### PR TITLE
ci: upgrade to go1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,15 +37,15 @@ env:
 
 matrix:
   include:
+    - go: "1.13.x"
+      env: CGO_ENABLED=0
     - go: "1.12.x"
       env: CGO_ENABLED=0
     - go: "1.11.x"
       env: CGO_ENABLED=0
-    - go: "1.10.x"
-      env: CGO_ENABLED=0
+    - go: "1.13.x"
     - go: "1.12.x"
     - go: "1.11.x"
-    - go: "1.10.x"
 
 services:
   - docker


### PR DESCRIPTION
Simple upgrade to latest go version.

I plan to work on #520 (I hope to be able to use the mbtile "offline" later) and maybe others issues somewhat related #602 #583. But before, I would suggest this unrelated change. 😄 